### PR TITLE
Add update entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added patch of type `UpdateEntity` to update multiple fields (without arguments) [#6](https://github.com/dividab/gql-cache-patch/issues/6).
+
 ## [v0.12.0] - 2019-04-01
 
 ### Added

--- a/src/apply.ts
+++ b/src/apply.ts
@@ -37,6 +37,10 @@ export function apply(
         applyCreateEntity(patch, cacheCopy);
         break;
       }
+      case "UpdateEntity": {
+        applyUpdateEntity(patch, cacheCopy);
+        break;
+      }
       case "DeleteEntity": {
         applyDeleteEntity(patch, cacheCopy);
         break;
@@ -188,6 +192,16 @@ function applyCreateEntity(
 ): void {
   // Shallow mutation OK as we have a shallow copy
   cache[patch.id] = patch.newValue;
+}
+
+function applyUpdateEntity(
+  patch: CachePatch.UpdateEntity,
+  cache: MutableEntityCache
+): void {
+  if (entityExists(cache, patch)) {
+    // Shallow mutation OK as we have a shallow copy
+    cache[patch.id] = { ...cache[patch.id], ...patch.newValues };
+  }
 }
 
 function applyDeleteEntity(

--- a/src/cache-patch.ts
+++ b/src/cache-patch.ts
@@ -6,6 +6,7 @@ export type CachePatch =
   | InvalidateField
   | CreateEntity
   | DeleteEntity
+  | UpdateEntity
   | UpdateField
   | InsertElement
   | RemoveElement
@@ -29,6 +30,12 @@ export interface CreateEntity {
   readonly type: "CreateEntity";
   readonly id: GraphQLCache.EntityId;
   readonly newValue: GraphQLCache.Entity;
+}
+
+export interface UpdateEntity {
+  readonly type: "UpdateEntity";
+  readonly id: GraphQLCache.EntityId;
+  readonly newValues: GraphQLCache.Entity;
 }
 
 export interface DeleteEntity {
@@ -110,6 +117,17 @@ export function createEntity<T = GraphQLCache.Entity>(
 ): CreateEntity {
   // tslint:disable-next-line:no-any
   return { type: "CreateEntity", id, newValue: newValue as any };
+}
+
+/**
+ * Update multiple fields (without arguments) on an existing entity
+ */
+export function updateEntity<T = GraphQLCache.Entity>(
+  id: GraphQLCache.EntityId,
+  newValues: Partial<T>
+): UpdateEntity {
+  // tslint:disable-next-line:no-any
+  return { type: "UpdateEntity", id, newValues: newValues as any };
 }
 
 /**

--- a/test/test-data.ts
+++ b/test/test-data.ts
@@ -1,4 +1,5 @@
 import { createEntityTestData } from "./test-data/create-entity";
+import { updateEntityTestData } from "./test-data/update-entity";
 import { deleteEntityTestData } from "./test-data/delete-entity";
 import { updateFieldTestData } from "./test-data/update-field";
 import { insertElementTestData } from "./test-data/insert-element";
@@ -11,6 +12,7 @@ import { OneTest } from "./test-data/one-test";
 
 export const testData: ReadonlyArray<OneTest> = [
   ...createEntityTestData,
+  ...updateEntityTestData,
   ...deleteEntityTestData,
   ...updateFieldTestData,
   ...insertElementTestData,

--- a/test/test-data/update-entity.ts
+++ b/test/test-data/update-entity.ts
@@ -14,5 +14,11 @@ export const updateEntityTestData: ReadonlyArray<OneTest> = [
     patches: [updateEntity("obj1", { name: "foo", bar: "zoo" })],
     cacheBefore: { obj1: { id: "obj1", name: "name", bar: "bar" } },
     cacheAfter: { obj1: { id: "obj1", name: "foo", bar: "zoo" } }
+  },
+  {
+    name: "updateEntity should create fields that does not exist in cache",
+    patches: [updateEntity("obj1", { name: "foo", bar: "zoo" })],
+    cacheBefore: { obj1: { id: "obj1", name: "name" } },
+    cacheAfter: { obj1: { id: "obj1", name: "foo", bar: "zoo" } }
   }
 ];

--- a/test/test-data/update-entity.ts
+++ b/test/test-data/update-entity.ts
@@ -1,0 +1,18 @@
+import { updateEntity } from "../../src";
+import { OneTest } from "./one-test";
+
+export const updateEntityTestData: ReadonlyArray<OneTest> = [
+  {
+    name:
+      "updateEntity should not do anything if entity does not exist in cache",
+    patches: [updateEntity("obj1", { name: "foo", bar: "zoo" })],
+    cacheBefore: {},
+    cacheAfter: {}
+  },
+  {
+    name: "updateEntity should update if entity exist in cache",
+    patches: [updateEntity("obj1", { name: "foo", bar: "zoo" })],
+    cacheBefore: { obj1: { id: "obj1", name: "name", bar: "bar" } },
+    cacheAfter: { obj1: { id: "obj1", name: "foo", bar: "zoo" } }
+  }
+];


### PR DESCRIPTION
This PR will add a new patch type `UpdateEntity` that can update multiple fields with one patch. However this type cannot specify arguments for the fields. In case arguments are needed the type `UpdateField` must be used.

Fixes #6 .